### PR TITLE
Use actual class and function name with Debug.LogError

### DIFF
--- a/Assets/FuseSDK/Android/FuseSDK_Prime31_IAB.cs
+++ b/Assets/FuseSDK/Android/FuseSDK_Prime31_IAB.cs
@@ -80,12 +80,12 @@ public class FuseSDK_Prime31_IAB : MonoBehaviour
 				}
 				catch
 				{
-					Debug.LogError("Fuse Unibill Tracking: Error parsing " + priceString + " >> Unable to parse " + stripped);
+					Debug.LogError("FuseSDK_Prime31_IAB::GetSkuInfo - Error parsing " + priceString + " >> Unable to parse " + stripped);
 				}
 			}
 			else
 			{
-				Debug.LogError("Fuse Unibill Tracking: Error parsing " + priceString + " >> String did not match regex");
+				Debug.LogError("FuseSDK_Prime31_IAB::GetSkuInfo - Error parsing " + priceString + " >> String did not match regex");
 			}
 		}
 


### PR DESCRIPTION
Debug.LogError as referring to Unibill when it should refer to Prime31_IAB